### PR TITLE
Only attempt to reload namespaces that are already loaded

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -2,7 +2,7 @@
  :resource-paths #{"src"}
  :dependencies '[[org.clojure/clojure "1.8.0" :scope "provided"]
                  [boot/core "2.6.0" :scope "provided"]
-                 [org.clojure/tools.namespace "0.2.11"]
+                 [org.clojure/tools.namespace "0.3.0-alpha3"]
                  [adzerk/bootlaces "0.1.13" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])

--- a/src/samestep/boot_refresh.clj
+++ b/src/samestep/boot_refresh.clj
@@ -1,16 +1,35 @@
 (ns samestep.boot-refresh
   {:boot/export-tasks true}
   (:require [boot.core :as boot]
-            [clojure.tools.namespace.repl :as tns]))
+            [boot.util :as util]
+            [clojure.tools.namespace.dir :as dir]
+            [clojure.tools.namespace.track :as track]
+            [clojure.tools.namespace.reload :as reload]))
 
 (boot/deftask refresh
   "Reload all changed namespaces on the classpath.
 
   Throws an exception in the case of failure."
   []
-  (boot/with-pass-thru _
-    (apply tns/set-refresh-dirs (boot/get-env :directories))
-    (with-bindings {#'*ns* *ns*}
-      (let [result (tns/refresh)]
-        (when (instance? Throwable result)
-          (throw result))))))
+  (let [tracker (atom nil)
+        filter-ns (fn [ns] (filter find-ns ns))]
+    (boot/with-pass-thru _
+      (swap! tracker
+             (fn [tracker]
+               (util/dbug "Scan directories: %s\n" (pr-str (boot/get-env :directories)))
+               (-> (or tracker (track/tracker))
+                   (dir/scan-dirs (boot/get-env :directories))
+                   ;; Only reload namespaces which are already loaded
+                   (update ::track/load filter-ns)
+                   (update ::track/unload filter-ns))))
+      (util/info "Unload: %s\n" (pr-str (::track/unload @tracker)))
+      (util/info "Load: %s\n" (pr-str (::track/load @tracker)))
+      (swap! tracker reload/track-reload)
+      (try
+        (when (::reload/error @tracker)
+          (util/fail "Error reloading: %s\n" (name (::reload/error-ns @tracker)))
+          (throw (::reload/error @tracker)))
+        (catch java.io.FileNotFoundException e
+          (util/info "Resetting tracker due to file not found exception, all namespaces will be reloaded next time.\n")
+          (reset! tracker (track/tracker))
+          (throw e))))))

--- a/src/samestep/boot_refresh/impl.clj
+++ b/src/samestep/boot_refresh/impl.clj
@@ -1,0 +1,28 @@
+(ns samestep.boot-refresh.impl
+  (:require [boot.util :as util]
+            [clojure.tools.namespace.dir :as dir]
+            [clojure.tools.namespace.track :as track]
+            [clojure.tools.namespace.reload :as reload]))
+
+(defn refresh-env
+  [tracker dirs]
+  (let [filter-ns (fn [ns] (filter find-ns ns))]
+    (swap! tracker
+           (fn [tracker]
+             (util/dbug "Scan directories: %s\n" (pr-str dirs))
+             (-> (or tracker (track/tracker))
+                 (dir/scan-dirs dirs)
+                 ;; Only reload namespaces which are already loaded
+                 (update ::track/load filter-ns)
+                 (update ::track/unload filter-ns))))
+    (util/info "Unload: %s\n" (pr-str (::track/unload @tracker)))
+    (util/info "Load: %s\n" (pr-str (::track/load @tracker)))
+    (swap! tracker reload/track-reload)
+    (try
+      (when (::reload/error @tracker)
+        (util/fail "Error reloading: %s\n" (name (::reload/error-ns @tracker)))
+        (throw (::reload/error @tracker)))
+      (catch java.io.FileNotFoundException e
+        (util/info "Resetting tracker due to file not found exception, all namespaces will be reloaded next time.\n")
+        (reset! tracker (track/tracker))
+        (throw e)))))


### PR DESCRIPTION
Reloading all of the directories that boot can see results in errors, if those directories contain namespaces that are intended to be used in pods with different dependencies than the main boot environment. By only reloading namespaces that have already been loaded, this implementation avoids running into these missing dependency errors.

Credit to @Deraen - I only lightly edited his implementation of this pattern in Perun, here: https://github.com/hashobject/perun/blob/master/src/io/perun/render.clj